### PR TITLE
fix: use title and imageUrl from plugin config instead semantic-release config

### DIFF
--- a/src/success.js
+++ b/src/success.js
@@ -6,7 +6,7 @@ module.exports = async (pluginConfig, context) => {
   const { webhookUrl } = pluginConfig
   const url = webhookUrl || env.TEAMS_WEBHOOK_URL
   const headers = { 'Content-Type': 'application/json' }
-  const body = await JSON.stringify(teamsify(context))
+  const body = await JSON.stringify(teamsify(pluginConfig, context))
 
   fetch(url, { method: 'post', body, headers})
     .then(() => logger.log('Message sent to Microsoft Teams'))

--- a/src/teamsify.js
+++ b/src/teamsify.js
@@ -19,10 +19,10 @@ const mdOptions = {
  * @param context semantic-release plugin context
  * @returns {Object}
  */
-const baseMessage = (context) => {
+const baseMessage = (pluginConfig, context) => {
   const { nextRelease, lastRelease, commits, options } = context
   const repository = options.repositoryUrl.split('/').pop()
-  const { title, imageUrl } = options
+  const { title, imageUrl } = pluginConfig
 
   const facts = []
 
@@ -53,7 +53,7 @@ const baseMessage = (context) => {
     summary: title || 'A new version has been released',
     sections: [
       {
-        activityTitle: `A new version has been released`,
+        activityTitle: title || 'A new version has been released',
         activitySubtitle: repository,
         activityImage: imageUrl || 'https://upload.wikimedia.org/wikipedia/commons/thumb/4/4e/Gitlab_meaningful_logo.svg/144px-Gitlab_meaningful_logo.svg.png',
         facts,
@@ -109,9 +109,9 @@ const extractSections = (context) => {
   return sections
 }
 
-module.exports = (context) => {
+module.exports = (pluginConfig, context) => {
   const sections = extractSections(context)
-  const teamsMessage = baseMessage(context)
+  const teamsMessage = baseMessage(pluginConfig, context)
 
   if (sections.length > 0) {
     teamsMessage.sections.push({ text: '---' })


### PR DESCRIPTION
At the current realisation you should set image and title not in plugin config. It was read from semantic-release config.

Fix it.

Also title changes (even on top of semantic-release config) doest not affect. Looks like we should use title form config to  `activityTitle` too