### PR TITLE
fix(ci): publish on npm registry too

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -35,6 +35,7 @@ jobs:
       - run: npm ci
       - run: npm run release -- --dry-run
         env:
+          NPM_TOKEN: ${{secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           TEAMS_WEBHOOK_URL: ${{ secrets.TEAMS_WEBHOOK_URL }}
 
@@ -50,5 +51,6 @@ jobs:
       - run: npm ci
       - run: npm run release
         env:
+          NPM_TOKEN: ${{secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           TEAMS_WEBHOOK_URL: ${{ secrets.TEAMS_WEBHOOK_URL }}

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "url": "https://github.com/yllieth/semantic-release-ms-teams/issues"
   },
   "homepage": "https://github.com/yllieth/semantic-release-ms-teams#readme",
-  "private": true,
   "files": [
     "index.js",
     "lib/*.js",


### PR DESCRIPTION
the workflow is setup to publish on github, which is fine, but we want to continue publish updates on NPM registry too