### PR TITLE
feat: replace aggregate-error library with standard NodeJS AggregateError

### DIFF
--- a/__tests__/lib/lifecycle-verify-condiftions.spec.js
+++ b/__tests__/lib/lifecycle-verify-condiftions.spec.js
@@ -29,7 +29,7 @@ describe('lifecycleVerifyConditions', () => {
     } catch (e) {
       // assert
       expect(e.name).toBe('AggregateError')
-      expect(e._errors[0].message).toBe('Invalid WebHook URL')
+      expect(e.errors[0].message).toBe('Invalid WebHook URL')
     }
 
     // assume
@@ -45,7 +45,7 @@ describe('lifecycleVerifyConditions', () => {
     } catch (e) {
       // assert
       expect(e.name).toBe('AggregateError')
-      expect(e._errors[0].message).toBe('Invalid WebHook URL')
+      expect(e.errors[0].message).toBe('Invalid WebHook URL')
     }
 
     // assume
@@ -61,7 +61,7 @@ describe('lifecycleVerifyConditions', () => {
     } catch (e) {
       // assert
       expect(e.name).toBe('AggregateError')
-      expect(e._errors[0].message).toBe('Invalid WebHook URL')
+      expect(e.errors[0].message).toBe('Invalid WebHook URL')
     }
 
     // assume
@@ -77,7 +77,7 @@ describe('lifecycleVerifyConditions', () => {
     } catch (e) {
       // assert
       expect(e.name).toBe('AggregateError')
-      expect(e._errors[0].message).toBe('Invalid WebHook URL')
+      expect(e.errors[0].message).toBe('Invalid WebHook URL')
     }
 
     // assume
@@ -93,7 +93,7 @@ describe('lifecycleVerifyConditions', () => {
     } catch (e) {
       // assert
       expect(e.name).toBe('AggregateError')
-      expect(e._errors[0].message).toBe('Invalid WebHook URL')
+      expect(e.errors[0].message).toBe('Invalid WebHook URL')
     }
 
     // assume
@@ -120,7 +120,7 @@ describe('lifecycleVerifyConditions', () => {
     } catch (e) {
       // assert
       expect(e.name).toBe('AggregateError')
-      expect(e._errors[0].message).toBe('Invalid WebHook URL')
+      expect(e.errors[0].message).toBe('Invalid WebHook URL')
     }
 
     // assume
@@ -136,7 +136,7 @@ describe('lifecycleVerifyConditions', () => {
     } catch (e) {
       // assert
       expect(e.name).toBe('AggregateError')
-      expect(e._errors[0].message).toBe('Invalid WebHook URL')
+      expect(e.errors[0].message).toBe('Invalid WebHook URL')
     }
 
     // assume
@@ -152,7 +152,7 @@ describe('lifecycleVerifyConditions', () => {
     } catch (e) {
       // assert
       expect(e.name).toBe('AggregateError')
-      expect(e._errors[0].message).toBe('Invalid WebHook URL')
+      expect(e.errors[0].message).toBe('Invalid WebHook URL')
     }
 
     // assume
@@ -168,7 +168,7 @@ describe('lifecycleVerifyConditions', () => {
     } catch (e) {
       // assert
       expect(e.name).toBe('AggregateError')
-      expect(e._errors[0].message).toBe('Invalid WebHook URL')
+      expect(e.errors[0].message).toBe('Invalid WebHook URL')
     }
 
     // assume

--- a/lib/lifecycle-verify-conditions.js
+++ b/lib/lifecycle-verify-conditions.js
@@ -1,4 +1,4 @@
-const AggregateError = require('aggregate-error')
+const SemanticReleaseError = require('@semantic-release/error')
 
 /* eslint-disable no-useless-escape */
 const URL_PATTERN =
@@ -39,6 +39,7 @@ module.exports = (pluginConfig, context) => {
 
   // Throw any errors we accumulated during the validation
   if (errors.length > 0) {
-    throw new AggregateError(errors)
+    throw new AggregateError(errors.map((message) => new SemanticReleaseError(message)))
+    //    throw new SemanticReleaseError(...errors)
   }
 }

--- a/package.json
+++ b/package.json
@@ -59,6 +59,6 @@
     "semantic-release": "^19.0.3"
   },
   "peerDependencies": {
-    "semantic-release": "19"
+    "semantic-release": ">=19"
   }
 }


### PR DESCRIPTION
In a new project I encountered problems in the interaction of this library and the latest version of Semantic-Release (23.0.5):

```bash
$ yarn release --dry-run
[08:56:28] [semantic-release] » ℹ  Running semantic-release version 23.0.5
[08:56:28] [semantic-release] » ✘  An error occurred while running semantic-release: Error [ERR_REQUIRE_ESM]: require() of ES Module C:\<project-path>\node_modules\aggregate-error\index.js from C:\<project-path>\node_modules\semantic-release-ms-teams\lib\lifecycle-verify-conditions.js not supported.
Instead change the require of index.js in C:\<project-path>\node_modules\semantic-release-ms-teams\lib\lifecycle-verify-conditions.js to a dynamic import() which is available in all CommonJS modules.
    at Object.<anonymous> (C:\<project-path>\node_modules\semantic-release-ms-teams\lib\lifecycle-verify-conditions.js:1:24) {
  code: 'ERR_REQUIRE_ESM'
}
Error [ERR_REQUIRE_ESM]: require() of ES Module C:\<project-path>\node_modules\aggregate-error\index.js from C:\<project-path>\node_modules\semantic-release-ms-teams\lib\lifecycle-verify-conditions.js not supported.
Instead change the require of index.js in C:\<project-path>\node_modules\semantic-release-ms-teams\lib\lifecycle-verify-conditions.js to a dynamic import() which is available in all CommonJS modules.
    at Object.<anonymous> (C:\<project-path>\node_modules\semantic-release-ms-teams\lib\lifecycle-verify-conditions.js:1:24) {
  code: 'ERR_REQUIRE_ESM'
}
```

As you can see in the log, it is not possible to import the library `aggregate-error` via `require`. This is no longer possible since [version 4.0](https://github.com/sindresorhus/aggregate-error/releases/tag/v4.0.0), as the library is delivered as a pure ESM package. Semantic-Release now uses version 5.0.0.

However, since NodeJS 15 it is possible to use the _"native"_ [AggregateError](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AggregateError) object. This change finally allows this library to be operated in the latest Semantic-Release version.

Fix #40