### PR TITLE
feat: Update Teams webhook payload format

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ This plugin is using an _incoming webhook_ to notify a teams channel. Here is
       "webhookUrl": "...",
       "title": "A new version has been released",
       "imageUrl": "http://...",
+      "adaptiveCardStyle": true,
       "showContributors": false,
       "notifyInDryRun": true,
     }]
@@ -39,16 +40,18 @@ This plugin is using an _incoming webhook_ to notify a teams channel. Here is
 }
 ```
 
-| Variable                                         | Details             | Description                                                                                                                   | 
-|--------------------------------------------------|---------------------|-------------------------------------------------------------------------------------------------------------------------------|
-| `webhookUrl` or `TEAMS_WEBHOOK_URL`              | **required**, url   | The incoming webhook url of the channel to publish release notes to.                                                          |
-| `webhookUrlDryRun` or `TEAMS_WEBHOOK_URL_DRYRUN` | _optional_, url     | Similar to `webhookUrl` or `TEAMS_WEBHOOK_URL`, but will be used in dryRun mode. Default: `webhookUrl` or `TEAMS_WEBHOOK_URL` |
-| `title`                                          | _optional_, text    | The title of the message. Default: _A new version has been released_                                                          |
-| `imageUrl`                                       | _optional_, url     | An image displayed in the message, next to the title. The image must be less than 200x200.                                    |
-| `showContributors`                               | _optional_, boolean | Whether or not the contributors should be displayed in the message. Default: `true`                                           |
-| `notifyInDryRun`                                 | _optional_, boolean | Whether or not the release notes will be send to Teams when semantic-release runs in dry-run mode. Default: `true`            |
+| Variable                                         | Details             | Description                                                                                                                         |
+|--------------------------------------------------|---------------------|-------------------------------------------------------------------------------------------------------------------------------------|
+| `webhookUrl` or `TEAMS_WEBHOOK_URL`              | **required**, url   | The incoming webhook url of the channel to publish release notes to.                                                                |
+| `webhookUrlDryRun` or `TEAMS_WEBHOOK_URL_DRYRUN` | _optional_, url     | Similar to `webhookUrl` or `TEAMS_WEBHOOK_URL`, but will be used in dryRun mode. Default: `webhookUrl` or `TEAMS_WEBHOOK_URL`       |
+| `title`                                          | _optional_, text    | The title of the message. Default: _A new version has been released_                                                                |
+| `imageUrl`                                       | _optional_, url     | An image displayed in the message, next to the title. The image must be less than 200x200.                                          |
+| `adaptiveCardStyle`                              | _optional_, boolean | Whether or not the webhook should be sent as `adaptiveCard` (for Power Automate webhooks) instead of `messageCard` Default: `false` |
+| `showContributors`                               | _optional_, boolean | Whether or not the contributors should be displayed in the message. Default: `true`                                                 |
+| `notifyInDryRun`                                 | _optional_, boolean | Whether or not the release notes will be send to Teams when semantic-release runs in dry-run mode. Default: `true`                  |
 
 ### Notes
+
 - `webhookUrl` is a property of the config object in `.releaserc.json`, and,
   `TEAMS_WEBHOOK_URL` is an environment variable. The config object can be
   useful to try the plugin, but most of the time, production environments
@@ -90,13 +93,16 @@ This plugin is using an _incoming webhook_ to notify a teams channel. Here is
 Here are some steps to test the plugin locally:
 
 - checkout the source code:
+
   ```sh
   git clone git@gitlab-ncsa.ubisoft.org:sragot/semantic-release-ms-teams.git
   cd semantic-release-ms-teams
   npm install
   ```
+
 - create a personal access token in github, then `export GH_TOKEN=...`
 - run `semantic-release` locally safely:
+
   ```sh
   npm link
   npm link semantic-release-ms-teams

--- a/lib/lifecycle-success.js
+++ b/lib/lifecycle-success.js
@@ -6,6 +6,18 @@ module.exports = async (pluginConfig, context) => {
   const { logger, env, options } = context
   const notifyInDryRun = pluginConfig.notifyInDryRun ?? true
   const url = getUrl(pluginConfig, context)
+  if (pluginConfig.adaptiveCardStyle === undefined) {
+    if (/^https:\/\/.*office\.com/.test(url)) {
+      logger.info('Webhook URL is an Office 365 webhook URL, using message card style.')
+      pluginConfig.adaptiveCardStyle = false
+    } else if (/^https:\/\/.*azure\.com/.test(url)) {
+      logger.info('Webhook URL is a Power Automate URL, using adaptive card style.')
+      pluginConfig.adaptiveCardStyle = true
+    } else {
+      logger.info('Webhook URL not recognized as O365 or Power Automate, using default message card style.')
+      pluginConfig.adaptiveCardStyle = false
+    }
+  }
   const headers = { 'Content-Type': 'application/json' }
   let body
   let teamsifyError = false

--- a/lib/teamsify.js
+++ b/lib/teamsify.js
@@ -19,7 +19,8 @@ const mdOptions = {
 const baseMessage = (pluginConfig, context, updates, isDryRunMode) => {
   const { nextRelease, lastRelease, commits, options, logger } = context
   const repository = options.repositoryUrl.split('/').pop()
-  const { title, imageUrl, adaptiveCardStyle, showContributors } = pluginConfig
+  const { title, imageUrl, adaptiveCardStyle } = pluginConfig ?? false
+  const { showContributors } = pluginConfig ?? true
 
   const facts = []
   let summary, nextVersion
@@ -35,8 +36,7 @@ const baseMessage = (pluginConfig, context, updates, isDryRunMode) => {
     nextVersion = `${nextRelease.gitTag} (${nextRelease.type})`
   }
 
-  const chosenImageUrl = imageUrl ?? 'https://upload.wikimedia.org/wikipedia/commons/thumb/4/4e/Gitlab_meaningful_logo.svg/144px-Gitlab_meaningful_logo.svg.png'
-  const useAdaptiveCardStyle = adaptiveCardStyle ?? false
+  let defaultImageUrl = 'https://upload.wikimedia.org/wikipedia/commons/thumb/4/4e/Gitlab_meaningful_logo.svg/144px-Gitlab_meaningful_logo.svg.png'
 
   facts.push({
     name: 'Version',
@@ -63,7 +63,7 @@ const baseMessage = (pluginConfig, context, updates, isDryRunMode) => {
       value: Array.from(contributors).join(', '),
     })
   }
-  if (!useAdaptiveCardStyle) {
+  if (!adaptiveCardStyle) {
     return {
       '@type': 'MessageCard',
       '@context': 'http://schema.org/extensions',
@@ -73,7 +73,7 @@ const baseMessage = (pluginConfig, context, updates, isDryRunMode) => {
         {
           activityTitle: summary,
           activitySubtitle: repository,
-          activityImage: chosenImageUrl,
+          activityImage: imageUrl || defaultImageUrl,
           facts,
           markdown: true,
         },
@@ -111,7 +111,7 @@ const baseMessage = (pluginConfig, context, updates, isDryRunMode) => {
                         items: [
                           {
                             type: 'Image',
-                            url: chosenImageUrl,
+                            url: imageUrl || defaultImageUrl,
                             altText: 'User icon',
                             size: 'medium',
                           }
@@ -223,10 +223,9 @@ module.exports = async (pluginConfig, context, isDryRunMode) => {
     throw new Error('Unable to load dependencies [remark, mdast-util-to-markdown]')
   }
   const { adaptiveCardStyle } = pluginConfig
-  const useAdaptiveCardStyle = adaptiveCardStyle ?? false
   const sections = extractSections(context)
   let updates = ''
-  if (useAdaptiveCardStyle) {
+  if (adaptiveCardStyle) {
     sections.forEach((section) => {
       updates += `**${section.name}**\n`
       updates += `${section.changes.replace('\n-', '\r-')}\n`
@@ -235,7 +234,7 @@ module.exports = async (pluginConfig, context, isDryRunMode) => {
   }
 
   const teamsMessage = baseMessage(pluginConfig, context, updates, isDryRunMode)
-  if (!useAdaptiveCardStyle) {
+  if (!adaptiveCardStyle) {
     if (sections.length > 0) {
       teamsMessage.sections.push({ text: '---' })
     }

--- a/lib/teamsify.js
+++ b/lib/teamsify.js
@@ -16,10 +16,10 @@ const mdOptions = {
  *
  * @see https://docs.microsoft.com/en-us/microsoftteams/platform/task-modules-and-cards/cards/cards-format?tabs=adaptive-md%2Cconnector-html#formatting-cards-with-markdown
  */
-const baseMessage = (pluginConfig, context, isDryRunMode) => {
+const baseMessage = (pluginConfig, context, updates, isDryRunMode) => {
   const { nextRelease, lastRelease, commits, options, logger } = context
   const repository = options.repositoryUrl.split('/').pop()
-  const { title, imageUrl, showContributors } = pluginConfig
+  const { title, imageUrl, adaptiveCardStyle, showContributors } = pluginConfig
 
   const facts = []
   let summary, nextVersion
@@ -29,11 +29,14 @@ const baseMessage = (pluginConfig, context, isDryRunMode) => {
 
     /* eslint-disable-next-line quotes */
     summary = "[DRY-RUN MODE] This is a preview of the next release's content"
-    nextVersion = `${nextRelease.type} version bump`
+    nextVersion = `${nextRelease.gitTag} (${nextRelease.type} version bump)`
   } else {
     summary = title || 'A new version has been released'
     nextVersion = `${nextRelease.gitTag} (${nextRelease.type})`
   }
+
+  const chosenImageUrl = imageUrl ?? 'https://upload.wikimedia.org/wikipedia/commons/thumb/4/4e/Gitlab_meaningful_logo.svg/144px-Gitlab_meaningful_logo.svg.png'
+  const useAdaptiveCardStyle = adaptiveCardStyle ?? false
 
   facts.push({
     name: 'Version',
@@ -60,23 +63,104 @@ const baseMessage = (pluginConfig, context, isDryRunMode) => {
       value: Array.from(contributors).join(', '),
     })
   }
-
-  return {
-    '@type': 'MessageCard',
-    '@context': 'http://schema.org/extensions',
-    themeColor: 'FC6D27', // gitlab orange
-    summary,
-    sections: [
-      {
-        activityTitle: summary,
-        activitySubtitle: repository,
-        activityImage:
-          imageUrl ||
-          'https://upload.wikimedia.org/wikipedia/commons/thumb/4/4e/Gitlab_meaningful_logo.svg/144px-Gitlab_meaningful_logo.svg.png',
-        facts,
-        markdown: true,
-      },
-    ],
+  if (!useAdaptiveCardStyle) {
+    return {
+      '@type': 'MessageCard',
+      '@context': 'http://schema.org/extensions',
+      themeColor: 'FC6D27', // gitlab orange
+      summary,
+      sections: [
+        {
+          activityTitle: summary,
+          activitySubtitle: repository,
+          activityImage: chosenImageUrl,
+          facts,
+          markdown: true,
+        },
+      ],
+    }
+  } else {
+    // Update all 'name' properties to 'title' before adding them to the JSON object
+    // This is because the adaptive card schema requires 'title' instead of 'name'
+    facts.forEach(fact => {
+      fact.title = fact.name
+      delete fact.name
+    })
+    return {
+      '@type': 'message',
+      attachments: [
+        {
+          contentType: 'application/vnd.microsoft.card.adaptive',
+          content: {
+            '$schema': 'http://adaptivecards.io/schemas/adaptive-card.json',
+            type: 'AdaptiveCard',
+            version: '1.3',
+            msteams: {
+              width: 'Full',
+            },
+            body: [
+              {
+                type: 'Container',
+                items: [
+                  {
+                    type: 'ColumnSet',
+                    columns: [
+                      {
+                        type: 'Column',
+                        width: 'auto',
+                        items: [
+                          {
+                            type: 'Image',
+                            url: chosenImageUrl,
+                            altText: 'User icon',
+                            size: 'medium',
+                          }
+                        ]
+                      },
+                      {
+                        type: 'Column',
+                        width: 'stretch',
+                        items: [
+                          {
+                            type: 'TextBlock',
+                            text: summary,
+                            weight: 'bolder',
+                            wrap: true
+                          },
+                          {
+                            type: 'TextBlock',
+                            spacing: 'none',
+                            text: repository,
+                            isSubtle: true,
+                            wrap: true
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                type: 'Container',
+                items: [
+                  {
+                    type: 'FactSet',
+                    facts: facts
+                  },
+                  {
+                    type: 'TextBlock',
+                    separator: true,
+                    spacing: 'extraLarge',
+                    text: updates,
+                    wrap: true
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    }
   }
 }
 
@@ -138,18 +222,29 @@ module.exports = async (pluginConfig, context, isDryRunMode) => {
   } catch (e) {
     throw new Error('Unable to load dependencies [remark, mdast-util-to-markdown]')
   }
-
+  const { adaptiveCardStyle } = pluginConfig
+  const useAdaptiveCardStyle = adaptiveCardStyle ?? false
   const sections = extractSections(context)
-  const teamsMessage = baseMessage(pluginConfig, context, isDryRunMode)
-
-  if (sections.length > 0) {
-    teamsMessage.sections.push({ text: '---' })
+  let updates = ''
+  if (useAdaptiveCardStyle) {
+    sections.forEach((section) => {
+      updates += `**${section.name}**\n`
+      updates += `${section.changes.replace('\n-', '\r-')}\n`
+      updates += '\n\n'
+    })
   }
 
-  sections.forEach((section) => {
-    teamsMessage.sections.push({ text: `## ${section.name}` })
-    teamsMessage.sections.push({ text: section.changes.replace('\n-', '\r-') })
-  })
+  const teamsMessage = baseMessage(pluginConfig, context, updates, isDryRunMode)
+  if (!useAdaptiveCardStyle) {
+    if (sections.length > 0) {
+      teamsMessage.sections.push({ text: '---' })
+    }
+
+    sections.forEach((section) => {
+      teamsMessage.sections.push({ text: `## ${section.name}` })
+      teamsMessage.sections.push({ text: section.changes.replace('\n-', '\r-') })
+    })
+  }
 
   return teamsMessage
 }


### PR DESCRIPTION
Updating `teamsify.js` to support the new Power Automate style of webhooks, which do not support MessageCard format but instead require AdaptiveCard.

In order to facilitate this without breaking legacy O365 webhook compatibility, I assigned a variable `adaptiveCardStyle` to toggle the payload formatting. Default is `false` which sends a MessageCard as always, but if `true` then AdaptiveCard will be sent instead. if `adaptiveCardStyle` is not set, the plugin will evaluate the webhook url and try to determine correct styling.

I have tested this extensively and both message formats work perfectly and appear very similarly.

Example AdaptiveCard payload (new) :
![adaptivecard](https://github.com/user-attachments/assets/e9d2fadd-dafc-40fd-b121-bcacbc9bef36)

Example MessageCard payload (old) :
![messagecard](https://github.com/user-attachments/assets/ea9917cd-fde3-49aa-98d3-4b1dc5431e58)

